### PR TITLE
Update letter-spacing const and export to use letterSpacing instead of fontWeight

### DIFF
--- a/src/props/text/letter-spacing.js
+++ b/src/props/text/letter-spacing.js
@@ -1,4 +1,4 @@
-const fontWeight = {
+const letterSpacing = {
   prop: 'letter-spacing',
   propName: 'ls',
   keywordValues: {
@@ -13,4 +13,4 @@ const fontWeight = {
   }
 }
 
-export default fontWeight;
+export default letterSpacing;


### PR DESCRIPTION
# What

This is an update for `letter-spacing.js` to use `const letterSpacing` and `export default letterSpacing`. Previously it was using `fontWeight` for both.