### PR TITLE
Add justify-content: space-evenly to Flexbox

### DIFF
--- a/src/props/layout/flexbox/justify-content.js
+++ b/src/props/layout/flexbox/justify-content.js
@@ -1,17 +1,18 @@
 const justifyContent = {
-  propName: 'justify',
-  prop: 'justify-content',
+  propName: "justify",
+  prop: "justify-content",
   keywordValues: {
-    separator: '-',
+    separator: "-",
     values: {
-      'center': 'center',
-      'end': 'flex-end',
-      'start': 'flex-start',
-      'between': 'space-between',
-      'around': 'space-around'
+      center: "center",
+      end: "flex-end",
+      start: "flex-start",
+      between: "space-between",
+      around: "space-around",
+      evenly: "space-evenly"
     }
   },
-  propGroup: 'Flexbox'
+  propGroup: "Flexbox"
 };
 
 export default justifyContent;


### PR DESCRIPTION
# What

This adds the Flexbox option for `justify-content: space-evenly`.

From [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content):

`space-evenly`
> The items are evenly distributed within the alignment container along the main axis. The spacing between each pair of adjacent items, the main-start edge and the first item, and the main-end edge and the last item, are all exactly the same.

## Show me, idiot!

<img width="374" alt="Screenshot 2019-04-23 15 12 32" src="https://user-images.githubusercontent.com/148972/56609117-5e3f6680-65da-11e9-88c5-6d855c7fb8af.png">